### PR TITLE
Strip non-ASCII chars from XML song roster

### DIFF
--- a/VIP_playlist_downloader.py
+++ b/VIP_playlist_downloader.py
@@ -31,6 +31,8 @@ namehacks = {
     "  X'mas Edit": " (X'mas Edit)"
 }
 
+total_song_data_size = 0
+
 def get_term_size():
     h = windll.kernel32.GetStdHandle(-12)
     csbi = create_string_buffer(22)
@@ -249,7 +251,6 @@ if __name__ == '__main__':
         print "Applied %s namehacks" % numnamehacks
         print 'Beginning downloads to: %s' % os.path.join(os.path.abspath('.'), clargs.dl_folder); print
 
-        total_song_data_size = 0
         downloaded_songs = 0
 
         for song in songlist:

--- a/VIP_playlist_downloader.py
+++ b/VIP_playlist_downloader.py
@@ -197,7 +197,7 @@ if __name__ == '__main__':
             print NameError("Error: Download folder cannot be named %s" % clargs.dl_folder)
             sys.exit(1)
 
-        print "Prepairing to download latest VIP playlist"
+        print "Preparing to download latest VIP playlist"
 
         rosternames = {
             'normal': 'http://vip.aersia.net/roster.xml',

--- a/VIP_playlist_downloader.py
+++ b/VIP_playlist_downloader.py
@@ -53,6 +53,8 @@ def getPrettyFileSizes(fsize, size = None):
     else:
         return sizelist.get(size)
 
+def removeNonAscii(s): return "".join(i for i in s if ord(i)<128)
+    
 def download(song, total_songs, current_song, location = ''):
     u = urllib2.urlopen(song.location)
     f = open(os.path.join(location, song.filename), 'wb')
@@ -218,7 +220,7 @@ if __name__ == '__main__':
 
 
         roster = requests.get(xmlroster)
-        treeroot = ET.fromstring(roster.text.replace('xmlns="http://xspf.org/ns/0/"',''))
+        treeroot = ET.fromstring(removeNonAscii(roster.text.replace('xmlns="http://xspf.org/ns/0/"','')))
 
         print treeroot.getchildren()[0][0].find('title').text
         print # "X Tracks (Last Update: M DD YY)" or something like that


### PR DESCRIPTION
XML parse was choking on an accented 'e' in an artist name.
I don't really know Python, one-liner to do it blatantly lifted from StackOverflow:
<http://stackoverflow.com/questions/1342000/how-to-make-the-python-interpreter-correctly-handle-non-ascii-characters-in-stri>

Thanks for making this, btw. I had a wget command line I used to use, but it didn't fix the names and junk.